### PR TITLE
chore: replace requirements link

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -317,7 +317,7 @@ Incendo maintains some processors that you may depend on in your projects:
 
 - [cloud-processors-confirmation](https://github.com/Incendo/cloud-processors/tree/master/cloud-processors-confirmation)
 - [cloud-processors-cooldown](https://github.com/Incendo/cloud-processors/tree/master/cloud-processors-cooldown)
-- [cloud-requirements](https://github.com/incendo/cloud-requirements)
+- [cloud-processors-requirements](https://github.com/Incendo/cloud-processors/tree/master/cloud-processors-requirements)
 
 #### Exception handling
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,7 @@ nav:
   - cloud-processors:
       - confirmation: https://github.com/Incendo/cloud-processors/tree/master/cloud-processors-confirmation
       - cooldown: https://github.com/Incendo/cloud-processors/tree/master/cloud-processors-cooldown
-      - requirements: https://github.com/incendo/cloud-requirements
+      - requirements: https://github.com/Incendo/cloud-processors/tree/master/cloud-processors-requirements
   - Other:
       - cloud-irc: other/irc.md
 theme:


### PR DESCRIPTION
requirements now lives in cloud-processors

<!-- readthedocs-preview incendocloud start -->
----
📚 Documentation preview 📚: https://incendocloud--20.org.readthedocs.build/en/20/

<!-- readthedocs-preview incendocloud end -->