### PR TITLE
Typo

### DIFF
--- a/docs/processors/confirmation.md
+++ b/docs/processors/confirmation.md
@@ -38,7 +38,7 @@ You then need to register the postprocessor to the command manager:
 
 ```java
 commandManager.registerCommandPostProcessor(
-  confirmationManager.createPostProcessor()
+  confirmationManager.createPostprocessor()
 );
 ```
 


### PR DESCRIPTION
Either the typo is in the docs or in the method

<!-- readthedocs-preview incendocloud start -->
----
📚 Documentation preview 📚: https://incendocloud--30.org.readthedocs.build/en/30/

<!-- readthedocs-preview incendocloud end -->