### PR TITLE
Add initial docs for ComponentParser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -316,7 +316,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/docs/minecraft/minecraft-extras.md
+++ b/docs/minecraft/minecraft-extras.md
@@ -16,6 +16,7 @@
 - [MinecraftExceptionHandler](#minecraft-exception-handler)
 - [RichDescription](#rich-description)
 - [TextColorParser](#text-color-parser)
+- [ComponentParser](#component-parser)
 
 </div>
 
@@ -147,4 +148,18 @@ It parses `NamedTextColor`, legacy color codes using `&` as well as hex codes.
 
 ```java
 ParserDescriptor<?, TextColor> parser = TextColorParser.textColorParser();
+```
+
+## Component Parser
+
+`ComponentParser` is a [parser](../core/index.md#parsers) which parses Adventure `Component`s via
+a specified "decoder" function.
+
+```java
+// This creates a parser that uses MiniMessage for decoding the argument, and uses
+// greedy string parsing.
+ParserDescriptor<?, Component> parser = ComponentParser.componentParser(
+  MiniMessage.miniMessage(),
+  StringParser.StringMode.GREEDY_FLAG_YIELDING
+);
 ```


### PR DESCRIPTION
Is this sufficient? Should I talk about the annotations this also uses?

<!-- readthedocs-preview incendocloud start -->
----
📚 Documentation preview 📚: https://incendocloud--33.org.readthedocs.build/en/33/

<!-- readthedocs-preview incendocloud end -->