### PR TITLE
Fix Requirements interface example

### DIFF
--- a/docs/processors/requirements.md
+++ b/docs/processors/requirements.md
@@ -18,7 +18,7 @@ by the generic types. Example:
 
 ```java
 public interface YourRequirementInterface
-  implements Requirement<YourSenderType, YourRequirementInterface> {
+  extends Requirement<YourSenderType, YourRequirementInterface> {
 
     // Example method
     @NonNull String errorMessage();


### PR DESCRIPTION
Fixes an incorrect code block which shows an interface `implementing` the Requirements interface, where it should be `extends`.

<!-- readthedocs-preview incendocloud start -->
----
📚 Documentation preview 📚: https://incendocloud--35.org.readthedocs.build/en/35/

<!-- readthedocs-preview incendocloud end -->