### PR TITLE
fix CloudKey example

### DIFF
--- a/docs/processors/requirements.md
+++ b/docs/processors/requirements.md
@@ -52,7 +52,7 @@ the requirements in the command meta and for the processor to access the stored 
 public static final CloudKey<Requirements<YourSenderType, YourRequirementInterface>>
   REQUIREMENT_KEY = CloudKey.of(
         "requirements",
-        new TypeToken<CloudKey<Requirements<YourSenderType, YourRequirementInterface>>>() {}
+        new TypeToken<>() {}
 );
 ```
 


### PR DESCRIPTION
Fixes the incorrect code that would result in `CloudKey<CloudKey<Requirements<C, T>>>`. It could be replaced by the correct arguments, but they are redundant, so the most refined invocation is the empty diamond `<>`.

<!-- readthedocs-preview incendocloud start -->
----
📚 Documentation preview 📚: https://incendocloud--36.org.readthedocs.build/en/36/

<!-- readthedocs-preview incendocloud end -->