### PR TITLE
Fix cloud-velocity maven central link pointing to cloud-paper artifact

### DIFF
--- a/docs/minecraft/velocity.md
+++ b/docs/minecraft/velocity.md
@@ -14,7 +14,7 @@
 
 ## Installation
 
-Cloud for Velocity is available through [Maven Central](https://central.sonatype.com/artifact/org.incendo/cloud-paper).
+Cloud for Velocity is available through [Maven Central](https://central.sonatype.com/artifact/org.incendo/cloud-velocity).
 
 {{ dependency_listing("velocity") }}
 


### PR DESCRIPTION


<!-- readthedocs-preview incendocloud start -->
----
📚 Documentation preview 📚: https://incendocloud--47.org.readthedocs.build/en/47/

<!-- readthedocs-preview incendocloud end -->