### PR TITLE
Update Fabric docs to use correct mod ID

### DIFF
--- a/docs/minecraft/modded/fabric.md
+++ b/docs/minecraft/modded/fabric.md
@@ -43,7 +43,7 @@ Merge the following into your `fabric.mod.json`:
 ```json
 {
   "depends": {
-    "cloud": "*"
+    "cloud-fabric": "*"
   }
 }
 ```


### PR DESCRIPTION
Previously the documentation for the [Fabric](https://fabricmc.net/) Cloud API implementation stated that developers should depend on cloud with a mod-id of `cloud` in their `fabric.mod.json` (https://cloud.incendo.org/minecraft/modded/fabric/#fabricmodjson), however we were informed that the correct mod ID is `cloud-fabric`.

This is a simple PR that fixes that.