### PR TITLE
Fix cloud-fabric mod ID

### DIFF
--- a/docs/minecraft/modded/fabric.md
+++ b/docs/minecraft/modded/fabric.md
@@ -43,7 +43,7 @@ Merge the following into your `fabric.mod.json`:
 ```json
 {
   "depends": {
-    "cloud-fabric": "*"
+    "cloud": "*"
   }
 }
 ```


### PR DESCRIPTION
This PR reverts https://github.com/Incendo/cloud-docs/pull/52 - the correct mod ID was https://github.com/Incendo/cloud-minecraft-modded/blob/master/cloud-fabric/src/main/resources/fabric.mod.json, thus the old docs were actually correct.


<!-- readthedocs-preview incendocloud start -->
----
📚 Documentation preview 📚: https://incendocloud--54.org.readthedocs.build/en/54/

<!-- readthedocs-preview incendocloud end -->